### PR TITLE
Add "release" test group that initially just includes compilation tests

### DIFF
--- a/Tests.xml
+++ b/Tests.xml
@@ -10,4 +10,9 @@
 	<test_group name="basic">
 		<test name="restartability"/>
 	</test_group>
+	<test_group name="release">
+		<test name="compile_gnu"/>
+		<test name="compile_intel"/>
+		<test name="compile_pgi"/>
+	</test_group>
 </all>

--- a/compile_gnu/compile_gnu.py
+++ b/compile_gnu/compile_gnu.py
@@ -37,14 +37,29 @@ def test(tparams, res):
 
 	os.system('cp -R '+src_dir+'/src .')
 	os.system('cp -R '+src_dir+'/Makefile .')
+
+	#
+	# First compile the init_atmosphere core
+	#
+	os.system('time make gfortran CORE=init_atmosphere > make.init.log 2>&1')
+	if not os.path.isfile('init_atmosphere_model') or not os.path.getsize('init_atmosphere_model') > 1000000:
+		res.set('err_msg', 'GNU build test failed to compile init_atmosphere_model')
+		res.set('err_code', 1)
+		res.set('success', False)
+		res.set('completed', True)
+		return
+
+	#
+	# Then clean and compile the atmosphere core
+	#
 	os.system('make clean CORE=atmosphere > clean.log 2>&1')
-	os.system('time make gfortran CORE=atmosphere > make.log 2>&1')
+	os.system('time make gfortran CORE=atmosphere > make.model.log 2>&1')
 	if os.path.isfile('atmosphere_model') and os.path.getsize('atmosphere_model') > 1000000:
 		res.set('err_msg', 'GNU build test passed')
 		res.set('err_code', 0)
 		res.set('success', True)
 	else:
-		res.set('err_msg', 'GNU build test failed')
+		res.set('err_msg', 'GNU build test failed to compile atmosphere_model')
 		res.set('err_code', 1)
 		res.set('success', False)
 

--- a/compile_gnu/compile_gnu.py
+++ b/compile_gnu/compile_gnu.py
@@ -1,0 +1,54 @@
+import os, sys, time
+
+nprocs = 1
+compatible_environments = ['kuusi']
+
+def setup(tparams):
+
+	return {'modset':'gnu'}
+
+def test(tparams, res):
+
+	env = tparams['env']
+	utils=env.get('utils')	
+
+	res.set('completed', False)
+	res.set('name', 'Build / GNU')
+
+	if not env:
+		print('No environment object passed to Build/GNU test, quitting')
+		return res
+	if not utils:
+		print('No utils module in test environment, quitting Build/GNU test')
+		return res
+
+	if not env.contains_modset('gnu'):
+		res.set('err_msg', 'In Build/GNU test(), no modset for gnu')
+		return res
+
+	e = env.mod_reset('gnu', {})
+	if e:
+		res.set('err_msg', "In Build/GNU test(), error resetting to the modset 'gnu'.")
+		res.set('err_code', e)
+		return res
+	
+
+	src_dir = tparams['src_dir']
+
+	os.system('cp -R '+src_dir+'/src .')
+	os.system('cp -R '+src_dir+'/Makefile .')
+	os.system('make clean CORE=atmosphere > clean.log 2>&1')
+	os.system('time make gfortran CORE=atmosphere > make.log 2>&1')
+	if os.path.isfile('atmosphere_model') and os.path.getsize('atmosphere_model') > 1000000:
+		res.set('err_msg', 'GNU build test passed')
+		res.set('err_code', 0)
+		res.set('success', True)
+	else:
+		res.set('err_msg', 'GNU build test failed')
+		res.set('err_code', 1)
+		res.set('success', False)
+
+
+	res.set('completed', True)
+	
+	return

--- a/compile_intel/compile_intel.py
+++ b/compile_intel/compile_intel.py
@@ -1,0 +1,54 @@
+import os, sys, time
+
+nprocs = 1
+compatible_environments = ['kuusi']
+
+def setup(tparams):
+
+	return {'modset':'intel'}
+
+def test(tparams, res):
+
+	env = tparams['env']
+	utils=env.get('utils')	
+
+	res.set('completed', False)
+	res.set('name', 'Build / Intel')
+
+	if not env:
+		print('No environment object passed to Build/Intel test, quitting')
+		return res
+	if not utils:
+		print('No utils module in test environment, quitting Build/Intel test')
+		return res
+
+	if not env.contains_modset('intel'):
+		res.set('err_msg', 'In Build/Intel test(), no modset for intel')
+		return res
+
+	e = env.mod_reset('intel', {})
+	if e:
+		res.set('err_msg', "In Build/Intel test(), error resetting to the modset 'intel'.")
+		res.set('err_code', e)
+		return res
+	
+
+	src_dir = tparams['src_dir']
+
+	os.system('cp -R '+src_dir+'/src .')
+	os.system('cp -R '+src_dir+'/Makefile .')
+	os.system('make clean CORE=atmosphere > clean.log 2>&1')
+	os.system('time make ifort CORE=atmosphere > make.log 2>&1')
+	if os.path.isfile('atmosphere_model') and os.path.getsize('atmosphere_model') > 1000000:
+		res.set('err_msg', 'Intel build test passed')
+		res.set('err_code', 0)
+		res.set('success', True)
+	else:
+		res.set('err_msg', 'Intel build test failed')
+		res.set('err_code', 1)
+		res.set('success', False)
+
+
+	res.set('completed', True)
+	
+	return

--- a/compile_intel/compile_intel.py
+++ b/compile_intel/compile_intel.py
@@ -37,14 +37,29 @@ def test(tparams, res):
 
 	os.system('cp -R '+src_dir+'/src .')
 	os.system('cp -R '+src_dir+'/Makefile .')
+
+	#
+	# First compile the init_atmosphere core
+	#
+	os.system('time make ifort CORE=init_atmosphere > make.init.log 2>&1')
+	if not os.path.isfile('init_atmosphere_model') or not os.path.getsize('init_atmosphere_model') > 1000000:
+		res.set('err_msg', 'Intel build test failed to compile init_atmosphere_model')
+		res.set('err_code', 1)
+		res.set('success', False)
+		res.set('completed', True)
+		return
+
+	#
+	# Then clean and compile the atmosphere core
+	#
 	os.system('make clean CORE=atmosphere > clean.log 2>&1')
-	os.system('time make ifort CORE=atmosphere > make.log 2>&1')
+	os.system('time make ifort CORE=atmosphere > make.model.log 2>&1')
 	if os.path.isfile('atmosphere_model') and os.path.getsize('atmosphere_model') > 1000000:
 		res.set('err_msg', 'Intel build test passed')
 		res.set('err_code', 0)
 		res.set('success', True)
 	else:
-		res.set('err_msg', 'Intel build test failed')
+		res.set('err_msg', 'Intel build test failed to compile atmosphere_model')
 		res.set('err_code', 1)
 		res.set('success', False)
 

--- a/compile_pgi/compile_pgi.py
+++ b/compile_pgi/compile_pgi.py
@@ -37,14 +37,29 @@ def test(tparams, res):
 
 	os.system('cp -R '+src_dir+'/src .')
 	os.system('cp -R '+src_dir+'/Makefile .')
+
+	#
+	# First compile the init_atmosphere core
+	#
+	os.system('time make pgi CORE=init_atmosphere > make.init.log 2>&1')
+	if not os.path.isfile('init_atmosphere_model') or not os.path.getsize('init_atmosphere_model') > 1000000:
+		res.set('err_msg', 'PGI build test failed to compile init_atmosphere_model')
+		res.set('err_code', 1)
+		res.set('success', False)
+		res.set('completed', True)
+		return
+
+	#
+	# Then clean and compile the atmosphere core
+	#
 	os.system('make clean CORE=atmosphere > clean.log 2>&1')
-	os.system('time make pgi CORE=atmosphere > make.log 2>&1')
+	os.system('time make pgi CORE=atmosphere > make.model.log 2>&1')
 	if os.path.isfile('atmosphere_model') and os.path.getsize('atmosphere_model') > 1000000:
 		res.set('err_msg', 'PGI build test passed')
 		res.set('err_code', 0)
 		res.set('success', True)
 	else:
-		res.set('err_msg', 'PGI build test failed')
+		res.set('err_msg', 'PGI build test failed to compile atmosphere_model')
 		res.set('err_code', 1)
 		res.set('success', False)
 

--- a/compile_pgi/compile_pgi.py
+++ b/compile_pgi/compile_pgi.py
@@ -1,0 +1,54 @@
+import os, sys, time
+
+nprocs = 1
+compatible_environments = ['kuusi']
+
+def setup(tparams):
+
+	return {'modset':'pgi'}
+
+def test(tparams, res):
+
+	env = tparams['env']
+	utils=env.get('utils')	
+
+	res.set('completed', False)
+	res.set('name', 'Build / PGI')
+
+	if not env:
+		print('No environment object passed to Build/PGI test, quitting')
+		return res
+	if not utils:
+		print('No utils module in test environment, quitting Build/PGI test')
+		return res
+
+	if not env.contains_modset('pgi'):
+		res.set('err_msg', 'In Build/PGI test(), no modset for pgi')
+		return res
+
+	e = env.mod_reset('pgi', {})
+	if e:
+		res.set('err_msg', "In Build/PGI test(), error resetting to the modset 'pgi'.")
+		res.set('err_code', e)
+		return res
+	
+
+	src_dir = tparams['src_dir']
+
+	os.system('cp -R '+src_dir+'/src .')
+	os.system('cp -R '+src_dir+'/Makefile .')
+	os.system('make clean CORE=atmosphere > clean.log 2>&1')
+	os.system('time make pgi CORE=atmosphere > make.log 2>&1')
+	if os.path.isfile('atmosphere_model') and os.path.getsize('atmosphere_model') > 1000000:
+		res.set('err_msg', 'PGI build test passed')
+		res.set('err_code', 0)
+		res.set('success', True)
+	else:
+		res.set('err_msg', 'PGI build test failed')
+		res.set('err_code', 1)
+		res.set('success', False)
+
+
+	res.set('completed', True)
+	
+	return


### PR DESCRIPTION
Right now, the compilation tests exercise the GNU, Intel, and PGI compilers,
but these tests have only been verified to work under the 'kuusi' environment.