### PR TITLE
Add tests for static interpolation with both MODIS and USGS land use

### DIFF
--- a/Tests.xml
+++ b/Tests.xml
@@ -14,5 +14,7 @@
 		<test name="compile_gnu"/>
 		<test name="compile_intel"/>
 		<test name="compile_pgi"/>
+		<test name="static_usgs"/>
+		<test name="static_modis"/>
 	</test_group>
 </all>

--- a/static_modis/inputs/namelist.init_atmosphere
+++ b/static_modis/inputs/namelist.init_atmosphere
@@ -1,0 +1,32 @@
+&nhyd_model
+    config_init_case = 7
+    config_start_time = '2017-01-01_00:00:00'
+    config_stop_time = '2017-01-01_00:00:00'
+    config_theta_adv_order = 3
+    config_coef_3rd_order = 0.25
+/
+&dimensions
+    config_nvertlevels = 1
+    config_nsoillevels = 1
+    config_nfglevels = 1
+    config_nfgsoillevels = 1
+/
+&data_sources
+    config_geog_data_path = './WPS_GEOG/'
+    config_landuse_data = 'MODIFIED_IGBP_MODIS_NOAH'
+/
+&preproc_stages
+    config_static_interp = true
+    config_native_gwd_static = true
+    config_vertical_grid = false
+    config_met_interp = false
+    config_input_sst = false
+    config_frac_seaice = false
+/
+&io
+    config_pio_num_iotasks = 0
+    config_pio_stride = 1
+/
+&decomposition
+    config_block_decomp_file_prefix = 'x1.40962.graph.info.part.'
+/

--- a/static_modis/inputs/streams.init_atmosphere
+++ b/static_modis/inputs/streams.init_atmosphere
@@ -1,0 +1,21 @@
+<streams>
+<immutable_stream name="input"
+                  type="input"
+                  filename_template="x1.40962.grid.nc"
+                  precision="double"
+                  input_interval="initial_only" />
+
+<immutable_stream name="output"
+                  type="output"
+                  filename_template="x1.40962.static_modis.nc"
+                  packages="initial_conds"
+                  output_interval="initial_only" />
+
+<immutable_stream name="surface"
+                  type="output"
+                  filename_template="x1.40962.sfc_update.nc"
+                  filename_interval="none"
+                  packages="sfc_update"
+                  output_interval="86400" />
+
+</streams>

--- a/static_modis/static_modis.py
+++ b/static_modis/static_modis.py
@@ -1,0 +1,68 @@
+import os, sys, time
+
+nprocs=1
+compatible_environments = ['kuusi']
+dependencies=['compile_gnu']
+
+def setup(tparams):
+
+	files = ['x1.40962.grid.nc', 'WPS_GEOG']
+	return {'files':files, 'modset':'gnu'}
+
+def test(tparams, res):
+
+	env = tparams['env']
+	utils=env.get('utils')	
+
+	res.set('completed', False)
+	res.set('name', 'Static interpolation (MODIS)')
+
+	if not env:
+		print('No environment object passed to Example test, quitting')
+		return res
+	if not utils:
+		print('No utils module in test environment, quitting Example test')
+		return res
+
+	if not env.contains_modset('gnu'):
+		res.set('err_msg', 'In Static/MODIS test(), no modset for gnu')
+		return res
+
+	e = env.mod_reset('gnu', {})
+	if e:
+		res.set('err_msg', "In Static/MODIS test(), error resetting to the modset 'gnu'.")
+		res.set('err_code', e)
+		return res
+	
+
+	template_dir = tparams['SMARTS_dir']+'/static_modis'
+	sandbox_dir = tparams['test_dir']
+	exe_dir = tparams['test_dir']+'/../compile_gnu'
+
+	os.system('ln -s '+exe_dir+'/init_atmosphere_model .')
+	utils.linkAllFiles(template_dir+'/inputs', './')
+
+	#(completed, err_code) = runAtmosphereModel(dir, exename, ntasks, env, additional_lsf_options, additional_pbs_options)
+	#completed: boolean, signifies whether the function runAtmosphereModel completed or returned early
+	#err_code: the return code from the model executable
+	#Note: this function blocks until the model run is complete
+
+	#If your test comes with files like namelists and such, link them in this way
+	myRun = utils.modelRun('./', 'init_atmosphere_model', 1, env, add_lsfoptions={'-W':'1:30', '-e':'run.err', '-o':'run.out'})
+	myRun.runModelNonblocking() #returns immediately, model run happening in background
+
+	while not (myRun.is_finished()):
+		time.sleep(1)
+		pass
+
+	myRun.terminate()
+
+	e = myRun.get_result()
+
+	res.set('err_code', e.get('err_code'))
+
+	res.set('err_msg', 'Static interplation (MODIS) passed')
+
+	res.set('completed', True)
+	
+	return

--- a/static_usgs/inputs/namelist.init_atmosphere
+++ b/static_usgs/inputs/namelist.init_atmosphere
@@ -1,0 +1,32 @@
+&nhyd_model
+    config_init_case = 7
+    config_start_time = '2017-01-01_00:00:00'
+    config_stop_time = '2017-01-01_00:00:00'
+    config_theta_adv_order = 3
+    config_coef_3rd_order = 0.25
+/
+&dimensions
+    config_nvertlevels = 1
+    config_nsoillevels = 1
+    config_nfglevels = 1
+    config_nfgsoillevels = 1
+/
+&data_sources
+    config_geog_data_path = './WPS_GEOG/'
+    config_landuse_data = 'USGS'
+/
+&preproc_stages
+    config_static_interp = true
+    config_native_gwd_static = true
+    config_vertical_grid = false
+    config_met_interp = false
+    config_input_sst = false
+    config_frac_seaice = false
+/
+&io
+    config_pio_num_iotasks = 0
+    config_pio_stride = 1
+/
+&decomposition
+    config_block_decomp_file_prefix = 'x1.40962.graph.info.part.'
+/

--- a/static_usgs/inputs/streams.init_atmosphere
+++ b/static_usgs/inputs/streams.init_atmosphere
@@ -1,0 +1,21 @@
+<streams>
+<immutable_stream name="input"
+                  type="input"
+                  filename_template="x1.40962.grid.nc"
+                  precision="double"
+                  input_interval="initial_only" />
+
+<immutable_stream name="output"
+                  type="output"
+                  filename_template="x1.40962.static_usgs.nc"
+                  packages="initial_conds"
+                  output_interval="initial_only" />
+
+<immutable_stream name="surface"
+                  type="output"
+                  filename_template="x1.40962.sfc_update.nc"
+                  filename_interval="none"
+                  packages="sfc_update"
+                  output_interval="86400" />
+
+</streams>

--- a/static_usgs/static_usgs.py
+++ b/static_usgs/static_usgs.py
@@ -1,0 +1,69 @@
+import os, sys, time
+
+nprocs=1
+compatible_environments = ['kuusi']
+dependencies=['compile_gnu']
+
+def setup(tparams):
+
+	files = ['x1.40962.grid.nc', 'WPS_GEOG']
+	return {'files':files, 'modset':'gnu'}
+
+def test(tparams, res):
+
+	env = tparams['env']
+	utils=env.get('utils')	
+
+	res.set('completed', False)
+	res.set('name', 'Static interpolation (USGS)')
+
+	if not env:
+		print('No environment object passed to Example test, quitting')
+		return res
+	if not utils:
+		print('No utils module in test environment, quitting Example test')
+		return res
+
+	if not env.contains_modset('gnu'):
+		res.set('err_msg', 'In Static/USGS test(), no modset for gnu')
+		return res
+
+	e = env.mod_reset('gnu', {})
+	if e:
+		res.set('err_msg', "In Static/USGS test(), error resetting to the modset 'gnu'.")
+		res.set('err_code', e)
+		return res
+	
+
+	template_dir = tparams['SMARTS_dir']+'/static_usgs'
+	sandbox_dir = tparams['test_dir']
+	exe_dir = tparams['test_dir']+'/../compile_gnu'
+
+	os.system('ln -s '+exe_dir+'/init_atmosphere_model .')
+	utils.linkAllFiles(template_dir+'/inputs', './')
+
+	#(completed, err_code) = runAtmosphereModel(dir, exename, ntasks, env, additional_lsf_options, additional_pbs_options)
+	#completed: boolean, signifies whether the function runAtmosphereModel completed or returned early
+	#err_code: the return code from the model executable
+	#Note: this function blocks until the model run is complete
+
+	#If your test comes with files like namelists and such, link them in this way
+	myRun = utils.modelRun('./', 'init_atmosphere_model', 1, env, add_lsfoptions={'-W':'1:30', '-e':'run.err', '-o':'run.out'})
+	myRun.runModelNonblocking() #returns immediately, model run happening in background
+
+	while not (myRun.is_finished()):
+		time.sleep(1)
+		pass
+
+	myRun.terminate()
+
+	err = myRun.get_result()
+	print('Error code is '+repr(err.get('err_code')))
+
+	res.set('err_code', err.get('err_code'))
+
+	res.set('err_msg', 'Static interplation (USGS) passed')
+
+	res.set('completed', True)
+	
+	return


### PR DESCRIPTION
Note: The two new tests, 'static_usgs' and 'static_modis', require
new files from the Standard Library: x1.40962.grid.nc and WPS_GEOG/.