### PR TITLE
Add list of requested files to 'tparams'

### DIFF
--- a/test_driver.py
+++ b/test_driver.py
@@ -291,6 +291,7 @@ while unfinished_tests:
 						if utils.retrieveFileFromSL(files[i], locations[i], env):
 							found_files[i] = True
 					tparams['found_files'] = found_files
+					tparams['files'] = files
 
 				t.tparams = tparams
 				tests_in_progress[-1].start()


### PR DESCRIPTION
Having a matching list of filenames, 'files', that correspond to values in
'found_files' enables tests to generate more helpful error messages when
requested files aren't found in the standard library.