### PR TITLE
Add support for running jobs with PBS

### DIFF
--- a/test_driver.py
+++ b/test_driver.py
@@ -100,6 +100,10 @@ if root.get('type') == 'LSF':
 	env.set('lsf_options', options)
 elif root.get('type') == 'PBS':
 	env.set('type', utils.Environment.ENVPBS)
+	options = {}
+	for pbs_option in root.findall('pbs_option'):
+		options[pbs_option.get('name')] = pbs_option.get('value')
+	env.set('pbs_options', options)
 else:
 	env.set('type', utils.Environment.NONE)
 	

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -368,7 +368,22 @@ def runModel(dir, exename, n, env, add_lsfoptions={}, add_pbsoptions={}):
 
 	elif env.get('type') == Environment.ENVPBS:
 		print('Running on '+env.get('name')+', a PBS system.')
-		cmd = ''
+		args = []
+		pbs_options = env.get('pbs_options')
+		pbs_options['-W'] = 'block=true'
+		pbs_options['-N'] = exename
+		for key, value in pbs_options.items():
+			if key in add_pbsoptions:
+				continue
+			args.append(str(key) + ' ' + str(value))
+		for key, value in add_pbsoptions.items():
+			args.append(str(key) + ' ' + str(value))
+
+		args.append(' -l select=1:ncpus=' + str(n) + ':mpiprocs=' + str(n) + ' ')
+		os.system('echo \'#PBS ' + ' '.join(args) + '\' > script.' + exename)
+		os.system('echo \'mpiexec_mpt ./' + exename + '\' >> script.' + exename)
+		cmd = 'qsub script.' + exename
+		print(cmd)
 
 	elif env.get('name') == 'mmm' or env.get('type') == Environment.NONE:
 		cmd = 'mpirun -n '+str(n)+' ./'+exename


### PR DESCRIPTION
This commit adds changes in the top-level test_driver.py script as well
as in the utils module for running jobs that enable the system to run on
systems using PBS.

At least on Cheyenne, it seemed necessary to create a script file and then
qsub that file, rather than to submit the entire job on the command-line,
due to issues with qsub not finding the correct path for mpiexec_mpt or
the job to be run.