### PR TITLE
Add 'cheyenne' env, and update most 'release' tests to be compatible with Cheyenne

### DIFF
--- a/cheyenne.xml
+++ b/cheyenne.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<environment name="cheyenne" type="PBS" max_cores="144" modules="True" LMOD_CMD="/glade/u/apps/ch/opt/lmod/7.2.1/lmod/lmod/libexec/lmod" pathSL="/glade/p/mmm/duda/Standard-Library/">
+	<pbs_option name="-A" value="P64000101"/>
+	<pbs_option name="-q" value="regular"/>
+	<modset name="base">
+		<module name="ncarenv"/>
+		<module name="python"/>
+		<module name="numpy"/>
+		<module name="netcdf4-python"/>
+	</modset>
+	<modset name="gnu">
+		<module name="gnu">
+			<version v="6.3.0"/>
+		</module>
+		<module name="mpt"/>
+		<module name="ncarcompilers"/>
+		<module name="netcdf-mpi">
+			<version v="4.4.1.1"/>
+		</module>
+		<module name="pnetcdf">
+			<version v="1.8.0"/>
+		</module>
+		<module name="ncl"/>
+		<env_var name="PIO" value="/glade/p/work/duda/cheyenne/pio-1.9.23-gnu6.3.0"/>
+	</modset>
+	<modset name="intel" default="True" compiler="ifort">
+		<module name="intel">
+			<version v="17.0.1"/>
+		</module>
+		<module name="mpt"/>
+		<module name="ncarcompilers"/>
+		<module name="netcdf-mpi">
+			<version v="4.4.1.1"/>
+		</module>
+		<module name="pnetcdf">
+			<version v="1.8.0"/>
+		</module>
+		<env_var name="PIO" value="/glade/p/work/duda/cheyenne/pio-1.9.23"/>
+	</modset>
+</environment>

--- a/compile_gnu/compile_gnu.py
+++ b/compile_gnu/compile_gnu.py
@@ -1,7 +1,7 @@
 import os, sys, time
 
 nprocs = 1
-compatible_environments = ['kuusi']
+compatible_environments = ['kuusi','cheyenne']
 
 def setup(tparams):
 

--- a/compile_gnu_mtn_wave/compile_gnu_mtn_wave.py
+++ b/compile_gnu_mtn_wave/compile_gnu_mtn_wave.py
@@ -1,7 +1,7 @@
 import os, sys, time
 
 nprocs = 1
-compatible_environments = ['kuusi']
+compatible_environments = ['kuusi','cheyenne']
 
 def setup(tparams):
 

--- a/compile_intel/compile_intel.py
+++ b/compile_intel/compile_intel.py
@@ -1,7 +1,7 @@
 import os, sys, time
 
 nprocs = 1
-compatible_environments = ['kuusi']
+compatible_environments = ['kuusi','cheyenne']
 
 def setup(tparams):
 

--- a/ideal_mtn_wave/ideal_mtn_wave.py
+++ b/ideal_mtn_wave/ideal_mtn_wave.py
@@ -1,7 +1,7 @@
 import os, sys, time
 
 nprocs=1
-compatible_environments = ['kuusi']
+compatible_environments = ['kuusi','cheyenne']
 dependencies=['compile_gnu_mtn_wave']
 
 def setup(tparams):
@@ -48,9 +48,9 @@ def test(tparams, res):
 	os.system('ln -s '+exe_dir+'/atmosphere_model .')
 
 	utils.linkAllFiles(template_dir+'/inputs', './')
-	init = utils.modelRun('./', 'init_atmosphere_model', 1, env, add_lsfoptions={'-W':'0:30', '-e':'run.err', '-o':'run.out'})
+	init = utils.modelRun('./', 'init_atmosphere_model', 1, env, add_lsfoptions={'-W':'0:30', '-e':'run.err', '-o':'run.out'}, add_pbsoptions={'-l walltime=00:30:00':''})
 	init.runModelBlocking()
-	mtn_wave = utils.modelRun('./', 'atmosphere_model', 1, env, add_lsfoptions={'-W':'0:30', '-e':'run.err', '-o':'run.out'})
+	mtn_wave = utils.modelRun('./', 'atmosphere_model', 1, env, add_lsfoptions={'-W':'0:30', '-e':'run.err', '-o':'run.out'}, add_pbsoptions={'-l walltime=00:30:00':''})
 	mtn_wave.runModelBlocking()
 
 	e_init = init.get_result()

--- a/ideal_supercell/ideal_supercell.py
+++ b/ideal_supercell/ideal_supercell.py
@@ -1,7 +1,7 @@
 import os, sys, time
 
 nprocs=12
-compatible_environments = ['kuusi']
+compatible_environments = ['kuusi','cheyenne']
 dependencies=['compile_gnu']
 
 def setup(tparams):
@@ -48,9 +48,9 @@ def test(tparams, res):
 	os.system('ln -s '+exe_dir+'/atmosphere_model .')
 
 	utils.linkAllFiles(template_dir+'/inputs', './')
-	init = utils.modelRun('./', 'init_atmosphere_model', 1, env, add_lsfoptions={'-W':'0:30', '-e':'run.err', '-o':'run.out'})
+	init = utils.modelRun('./', 'init_atmosphere_model', 1, env, add_lsfoptions={'-W':'0:30', '-e':'run.err', '-o':'run.out'}, add_pbsoptions={'-l walltime=00:30:00':''})
 	init.runModelBlocking()
-	supercell = utils.modelRun('./', 'atmosphere_model', 12, env, add_lsfoptions={'-W':'0:30', '-e':'run.err', '-o':'run.out'})
+	supercell = utils.modelRun('./', 'atmosphere_model', 12, env, add_lsfoptions={'-W':'0:30', '-e':'run.err', '-o':'run.out'}, add_pbsoptions={'-l walltime=00:30:00':''})
 	supercell.runModelBlocking()
 
 	e_init = init.get_result()

--- a/static_modis/static_modis.py
+++ b/static_modis/static_modis.py
@@ -1,7 +1,7 @@
 import os, sys, time
 
 nprocs=1
-compatible_environments = ['kuusi']
+compatible_environments = ['kuusi','cheyenne']
 dependencies=['compile_gnu']
 
 def setup(tparams):
@@ -47,7 +47,7 @@ def test(tparams, res):
 	os.system('ln -s '+exe_dir+'/init_atmosphere_model .')
 	utils.linkAllFiles(template_dir+'/inputs', './')
 
-	myRun = utils.modelRun('./', 'init_atmosphere_model', 1, env, add_lsfoptions={'-W':'1:30', '-e':'run.err', '-o':'run.out'})
+	myRun = utils.modelRun('./', 'init_atmosphere_model', 1, env, add_lsfoptions={'-W':'1:30', '-e':'run.err', '-o':'run.out'}, add_pbsoptions={'-l walltime=01:30:00':''})
 	myRun.runModelNonblocking()
 
 	while not (myRun.is_finished()):

--- a/static_usgs/static_usgs.py
+++ b/static_usgs/static_usgs.py
@@ -1,7 +1,7 @@
 import os, sys, time
 
 nprocs=1
-compatible_environments = ['kuusi']
+compatible_environments = ['kuusi','cheyenne']
 dependencies=['compile_gnu']
 
 def setup(tparams):
@@ -47,7 +47,7 @@ def test(tparams, res):
 	os.system('ln -s '+exe_dir+'/init_atmosphere_model .')
 	utils.linkAllFiles(template_dir+'/inputs', './')
 
-	myRun = utils.modelRun('./', 'init_atmosphere_model', 1, env, add_lsfoptions={'-W':'1:30', '-e':'run.err', '-o':'run.out'})
+	myRun = utils.modelRun('./', 'init_atmosphere_model', 1, env, add_lsfoptions={'-W':'1:30', '-e':'run.err', '-o':'run.out'}, add_pbsoptions={'-l walltime=01:30:00':''})
 	myRun.runModelNonblocking()
 
 	while not (myRun.is_finished()):

--- a/test_driver.py
+++ b/test_driver.py
@@ -100,6 +100,10 @@ if root.get('type') == 'LSF':
 	env.set('lsf_options', options)
 elif root.get('type') == 'PBS':
 	env.set('type', utils.Environment.ENVPBS)
+	options = {}
+	for pbs_option in root.findall('pbs_option'):
+		options[pbs_option.get('name')] = pbs_option.get('value')
+	env.set('pbs_options', options)
 else:
 	env.set('type', utils.Environment.NONE)
 	

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -368,7 +368,22 @@ def runModel(dir, exename, n, env, add_lsfoptions={}, add_pbsoptions={}):
 
 	elif env.get('type') == Environment.ENVPBS:
 		print('Running on '+env.get('name')+', a PBS system.')
-		cmd = ''
+		args = []
+		pbs_options = env.get('pbs_options')
+		pbs_options['-W'] = 'block=true'
+		pbs_options['-N'] = exename
+		for key, value in pbs_options.items():
+			if key in add_pbsoptions:
+				continue
+			args.append(str(key) + ' ' + str(value))
+		for key, value in add_pbsoptions.items():
+			args.append(str(key) + ' ' + str(value))
+
+		args.append(' -l select=1:ncpus=' + str(n) + ':mpiprocs=' + str(n) + ' ')
+		os.system('echo \'#PBS ' + ' '.join(args) + '\' > script.' + exename)
+		os.system('echo \'mpiexec_mpt ./' + exename + '\' >> script.' + exename)
+		cmd = 'qsub script.' + exename
+		print(cmd)
 
 	elif env.get('name') == 'mmm' or env.get('type') == Environment.NONE:
 		cmd = 'mpirun -n '+str(n)+' ./'+exename


### PR DESCRIPTION
All tests in the 'release' group except for the 'compile_pgi' test (because there
are no PGI compilers as of now on Cheyenne) have been updated so that they are
compatible with the 'cheyenne' environment. For the tests that actually run jobs,
PBS options have been added.